### PR TITLE
フラッシュの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,11 @@
 .mw-xl {
   max-width: 1200px;
 }
+
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |flash_type, msg| %>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
       <%= render "layouts/header" %>
     </header>
     <main>
+      <%= render "layouts/flash" %>
       <%# max_width メソッドは `application_helper.rb` に記載 %>
       <div class="base-container <%= max_width %>">
         <%= yield %>


### PR DESCRIPTION

close #12

## 実装内容
  
- フラッシュの表示機能を実装
  - `_flash.html.erb`ファイルを作成してレンダリング
  - `alert-notice` の場合 `alert-success` となるようにスタイルを設定
  - `alert-alert` の場合 `alert-danger` となる等にスタイルを設定

## 参考資料
  
- フラッシュ機能
  - [やんばるエキスパートアプリ(メッセージ投稿アプリその3)](https://www.yanbaru-code.com/texts/270)
  
## チェックリスト
  
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
  
## 備考
- 動作確認
   - ログイン・ログアウトを実行してフラッシュが表示される確認済み

