### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,0 +1,15 @@
+.content-card {
+  height: 360px;
+  max-width: 376px;
+  margin: 0 auto;
+}
+
+.movie-fluid {
+  max-width: 100%;
+  height: auto;
+}
+
+.contents-title {
+  padding-top: 20px;
+  padding-bottom: 15px;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,3 +1,5 @@
 class MoviesController < ApplicationController
-  def index; end
+  def index
+    @movies = Movie.where(genre: Movie::RAILS_GENRE_LIST)
+  end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -7,6 +7,6 @@ module MoviesHelper
       frameborder: 0,
       allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
       allowfullscreen: true
-      )
+    )
   end
 end

--- a/app/helpers/movies_helper.rb
+++ b/app/helpers/movies_helper.rb
@@ -1,0 +1,12 @@
+module MoviesHelper
+  def embed_youtube(url)
+    tag.iframe(
+      width: 304,
+      height: 166,
+      src: url,
+      frameborder: 0,
+      allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
+      allowfullscreen: true
+      )
+  end
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -13,4 +13,6 @@ class Movie < ApplicationRecord
     rails: 4,
     php: 5
   }
+
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
 end

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,0 +1,11 @@
+<div class="col-12 col-md-6 col-lg-4">
+  <div class="card content-card border-dark mb-3">
+    <div class="card-header p-0">
+      <%= embed_youtube(movie.url) %>
+    </div>
+    <div class="card-body text-dark">
+      <object><a class="btn btn-secondary btn-block">読破済みにする</a></object>
+      <p class="card-text mt-3">LV.<%= movie.id %>：<%= movie.title %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -1,9 +1,11 @@
 <div class="col-12 col-md-6 col-lg-4">
   <div class="card content-card border-dark mb-3">
     <div class="card-header p-0">
-      <%= embed_youtube(movie.url) %>
+      <div class="embed-responsive embed-responsive-16by9">
+        <%= embed_youtube(movie.url) %>
+      </div>
     </div>
-    <div class="card-body text-dark">
+    <div class="card-body text-dark">      
       <object><a class="btn btn-secondary btn-block">読破済みにする</a></object>
       <p class="card-text mt-3">LV.<%= movie.id %>：<%= movie.title %></p>
     </div>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,0 +1,6 @@
+<div class="contents-title text-center">
+  <h1>Ruby/Rails 動画</h1>
+</div>
+<div class="row">
+  <%= render @movies %>
+</div>


### PR DESCRIPTION
close #15 

## 実装内容
- Rails動画教材の一覧ページを作成
  - 表示するジャンルを `Movie::RAILS_GENRE_LIST` に制限
  - Bootstrapの `Cards` や `Grid System` を使用
  - コレクションをレンダリング
  - 各動画にレベル表示
  - `app/assets/stylesheets/movies.scss` にスタイルを入力

## 動作確認
- 画像のようにレスポンシブ対応ができているかどうかを確認
- カードの高さが一定になっているか確認
- PHPの動画教材が表示されていないことを確認


## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
