### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,11 +13,11 @@ gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"
 gem "rails", "~> 6.1.1"
 gem "rails-i18n", "~> 6.0"
+gem "redcarpet"
+gem "rouge"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
-gem "redcarpet"
-gem "rouge"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem "rails-i18n", "~> 6.0"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
+gem "redcarpet"
+gem "rouge"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,11 +212,13 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
+    rouge (3.26.0)
     rubocop (1.17.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -303,6 +305,8 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
   rails-i18n (~> 6.0)
+  redcarpet
+  rouge
   rubocop-performance
   rubocop-rails
   sass-rails (>= 6)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,3 +40,7 @@
 body {
   padding-top: 56px;
 }
+
+a:hover {
+  text-decoration: none;
+}

--- a/app/assets/stylesheets/markdown.scss
+++ b/app/assets/stylesheets/markdown.scss
@@ -1,0 +1,46 @@
+@import 'bootstrap/scss/bootstrap';
+
+.markdown {
+  table {
+    @extend .table;
+    display: block;
+    overflow-x: scroll;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    border: initial;
+
+    thead {
+      background-color: #eeffff;
+    }
+  }
+
+  h1 {
+    font-size: 1.75rem;
+    text-align: left;
+  }
+
+  pre {
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
+    background-color: #f6ffff;
+    padding: 0.5rem;
+    margin: 1rem 0;
+    border: 2px dashed #d6dddd;
+
+    code {
+      table.rouge-table {
+        margin: 0;
+
+        td.rouge-code {
+          padding: 0;
+          vertical-align: top;
+
+          pre {
+            padding: 5px 10px;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/rouge.scss.erb
+++ b/app/assets/stylesheets/rouge.scss.erb
@@ -1,0 +1,1 @@
+<%= Rouge::Themes::Github.render(scope: '.highlight') %>

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -6,10 +6,4 @@ class TextsController < ApplicationController
   def show
     @text = Text.find(params[:id])
   end
-
-  private
-
-  def text_params
-    params.require(:text).permit(:title, :content)
-  end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -3,5 +3,13 @@ class TextsController < ApplicationController
     @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
   end
 
-  def show; end
+  def show
+    @text = Text.find(params[:id])
+  end
+
+  private
+
+  def text_params
+    params.require(:text).permit(:title, :content)
+  end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,30 @@
+module MarkdownHelper
+  def markdown(text)
+    renderer = Redcarpet::Render::HTML.new(render_options)
+    Redcarpet::Markdown.new(renderer, extensions).render(text).html_safe
+  end
+
+  private
+
+  def render_options
+    {
+      filter_html: false, # htmlを無効化
+      hard_wrap: true, # 改行を br 要素に変換
+      link_attributes: { target: "_blank", rel: "noopener" } # リンクの設定
+    }
+  end
+
+  def extensions
+    {
+      autolink: true, # http https ftpで始まる文字列を自動リンク
+      fenced_code_blocks: true, # コードブロックを解析
+      no_intra_emphasis: true, # 単語内の強調を解析しない
+      tables: true, # 	テーブルを解析
+      space_after_headers: true, # ヘッダーの先頭のハッシュとハッシュ名の間にスペースを要求
+      hard_wrap: true, # 改行を br 要素に変換
+      xhtml: true, # xhtml のタグを出力する(Render::XHTMLでは常に有効)
+      lax_html_blocks: true # 複数行のコードの前後に空行が不要
+      # strikethrough: true, # 取り消し線(~)を解析する
+    }
+  end
+end

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -1,16 +1,18 @@
 <div class="col-12 col-md-6 col-lg-4">
   <div class="card content-card border-dark mb-3">
-    <div class="card-header p-0">
-      <img loading="lazy" alt="<%= text.title%> "class="img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg">
-    </div>
-    <div class="card-body text-dark">
-      <p id="text-<%=text.id%>">
-        <object>
-          <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
-        </object>
-      </P>
-      <p class="card-text mt-3"><%= text.title%></p>
-      <p>【<%= text.genre_i18n %>】</p>
-    </div>
+    <%= link_to text_path(text) do %>
+      <div class="card-header p-0">
+        <img loading="lazy" alt="<%= text.title%> "class="img-fluid" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg">
+      </div>
+      <div class="card-body text-dark">
+        <p id="text-<%=text.id%>">
+          <object>
+            <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
+          </object>
+        </P>
+        <p class="card-text mt-3"><%= text.title%></p>
+        <p>【<%= text.genre_i18n %>】</p>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,16 +1,4 @@
-<% 
-  str = <<~TEXT
-  | HTTPメソッド | URL             | アクション   | 役割             |
-  |----------|-----------------|---------|----------------|
-  | GET      | /users          | index   | 一覧表示         |
-  | GET      | /users/new      | new     | 新規投稿フォーム表示 |
-  | POST     | /users          | create  | 新規投稿処理     |
-  | GET      | /users/:id      | show    | 詳細表示         |
-  | GET      | /users/:id/edit | edit    | 更新フォーム表示     |
-  | PATCH    | /users/:id      | update  | 更新処理         |
-  | DELETE   | /users/:id      | destroy | 削除処理         |
-TEXT
-%>
+<h1 class="text-center my-4" ><%= @text.title %></h1>
 <div class="markdown">
-  <%= markdown(str) %>
+  <%= markdown(@text.content) %>
 </div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,16 @@
+<% 
+  str = <<~TEXT
+  | HTTPメソッド | URL             | アクション   | 役割             |
+  |----------|-----------------|---------|----------------|
+  | GET      | /users          | index   | 一覧表示         |
+  | GET      | /users/new      | new     | 新規投稿フォーム表示 |
+  | POST     | /users          | create  | 新規投稿処理     |
+  | GET      | /users/:id      | show    | 詳細表示         |
+  | GET      | /users/:id/edit | edit    | 更新フォーム表示     |
+  | PATCH    | /users/:id      | update  | 更新処理         |
+  | DELETE   | /users/:id      | destroy | 削除処理         |
+TEXT
+%>
+<div class="markdown">
+  <%= markdown(str) %>
+</div>


### PR DESCRIPTION
close #17

## 実装内容


-  aタグの下線が入らないように `app/assets/stylesheets/application.scss` に設定 
- 一覧ページから詳細ページに移動できるように設定
- マークダウン形式を変換する` redcarpet`, シンタックスハイライトを適用する `rouge` をインストール
- `app/helpers/markdown_helper.rb` を作成し markdownメソッドを作成
- `app/assets/stylesheets/rouge.scss.erb` を作成し，`Rouge` のシンタックスハイライト用のスタイルを追加
- `app/assets/stylesheets/markdown.scss` を作成し，マークダウン専用のスタイルを追加
- 詳細ページを実装
  - 「タイトル(title)」と「内容(content)」を表示
  - 「内容」はマークダウンを変換した表示


## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

