### PR TITLE
ゲストログイン機能を追加

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,8 @@
+module Users
+  class SessionsController < Devise::SessionsController
+    def guest_sign_in
+      sign_in User.guest
+      redirect_to root_path, notice: "ゲストユーザーとしてログインしました。"
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
+
+  def self.guest
+    find_or_create_by!(email: "test@example.com") do |user|
+      user.password = SecureRandom.urlsafe_base64
+    end
+  end
 end

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,6 +3,8 @@
     <%= link_to "ログイン", new_session_path(resource_name), class: 'btn btn-secondary btn-block' %><br />
   <% end -%>
 
+  <%= link_to "ゲストログイン(閲覧用)", users_guest_sign_in_path, method: :post, class: "btn btn-success btn-block" %>
+
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
     <%= link_to "アカウント登録", new_registration_path(resource_name), class: 'btn btn-secondary btn-block' %><br />
   <% end -%>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -35,6 +35,9 @@
         <li class= "nav-item">
           <%= link_to "ログイン", new_user_session_path, class: "nav-item nav-link active" %>
         </li>
+        <li class= "nav-item">
+          <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "nav-item nav-link active" %>
+        </li>
       <% end %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@ Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   devise_for :users
+  devise_scope :user do
+    post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
+  end
   root "texts#index"
   resources :texts, only: [:index, :show]
   resources :movies, only: :index


### PR DESCRIPTION
close #19

## 実装内容
- ゲストログイン機能を実装
  - ナビバー、ログイン・新規登録のページに配置
  - ゲストユーザーのメールアドレスを `test@example.com` に設定

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
