### PR TITLE
動画教材の読破済み機能実装

### DIFF
--- a/app/controllers/watch_progresses_controller.rb
+++ b/app/controllers/watch_progresses_controller.rb
@@ -1,0 +1,11 @@
+class WatchProgressesController < ApplicationController
+  def create
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.create!(movie_id: @movie.id)
+  end
+
+  def destroy
+    @movie = Movie.find(params[:movie_id])
+    current_user.watch_progresses.find_by(movie_id: @movie.id).destroy!
+  end
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,4 +1,6 @@
 class Movie < ApplicationRecord
+  has_many :watch_progresses, dependent: :destroy
+
   with_options presence: true do
     validates :genre
     validates :title
@@ -15,4 +17,8 @@ class Movie < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  
+  def watch_by?(user)
+    watch_progresses.exists?(user_id: user.id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   has_many :read_progresses, dependent: :destroy
+  has_many :watch_progresses, dependent: :destroy
 
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable

--- a/app/models/watch_progress.rb
+++ b/app/models/watch_progress.rb
@@ -1,0 +1,5 @@
+class WatchProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :movie
+  validates :user_id, uniqueness: { scope: :movie_id }
+end

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -5,8 +5,16 @@
         <%= embed_youtube(movie.url) %>
       </div>
     </div>
-    <div class="card-body text-dark">      
-      <object><a class="btn btn-secondary btn-block">読破済みにする</a></object>
+    <div class="card-body text-dark">
+      <p id="movie-<%= movie.id %>">
+        <object>
+          <% if movie.watch_by?(current_user) %>
+            <%= render "watch", movie: movie %>
+          <% else %>
+            <%= render "unwatch", movie: movie %>
+          <% end %>
+        </object>
+      </p> 
       <p class="card-text mt-3">LV.<%= @movies.offset_value + 1 + movie_counter %>：<%= movie.title %></p>
     </div>
   </div>

--- a/app/views/movies/_unwatch.html.erb
+++ b/app/views/movies/_unwatch.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みにする", movie_watch_progresses_path(movie), method: :post, remote: true, class: "btn btn-secondary btn-block" %>

--- a/app/views/movies/_watch.html.erb
+++ b/app/views/movies/_watch.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みを解除", movie_watch_progresses_path(movie), method: :delete, remote: true, class: "btn btn-primary btn-block" %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -9,3 +9,4 @@
   <%= render @movies %>
 </div>
 <%= paginate @movies %>
+

--- a/app/views/watch_progresses/create.js.erb
+++ b/app/views/watch_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/watch", movie: @movie) %>'

--- a/app/views/watch_progresses/destroy.js.erb
+++ b/app/views/watch_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('movie-<%= @movie.id %>').innerHTML = '<%= j render("movies/unwatch", movie: @movie) %>'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,7 @@ Rails.application.routes.draw do
   resources :texts, only: [:index, :show] do
     resource :read_progresses, only: [:create, :destroy]
   end
-  resources :movies, only: :index
+  resources :movies, only: [:index, :show] do
+    resource :watch_progresses, only: [:create, :destroy]
+  end
 end

--- a/db/migrate/20210809163718_create_watch_progresses.rb
+++ b/db/migrate/20210809163718_create_watch_progresses.rb
@@ -1,0 +1,11 @@
+class CreateWatchProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :watch_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :movie, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :watch_progresses, [:user_id, :movie_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_21_104215) do
+ActiveRecord::Schema.define(version: 2021_08_09_163718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,18 @@ ActiveRecord::Schema.define(version: 2021_07_21_104215) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  create_table "watch_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "movie_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["movie_id"], name: "index_watch_progresses_on_movie_id"
+    t.index ["user_id", "movie_id"], name: "index_watch_progresses_on_user_id_and_movie_id", unique: true
+    t.index ["user_id"], name: "index_watch_progresses_on_user_id"
+  end
+
   add_foreign_key "read_progresses", "texts"
   add_foreign_key "read_progresses", "users"
+  add_foreign_key "watch_progresses", "movies"
+  add_foreign_key "watch_progresses", "users"
 end


### PR DESCRIPTION
close 23番号

## 実装内容
- 視聴済み機能に使用する `WatchProgress` モデルを作成
  - 外部キー設定を行い，ユニーク制約を入れてからマイグレーション
  - バリデーションをモデルに追加
  - 関連付けを入れる

- 動画教材一覧ページに視聴済み機能を実装
  - 非同期で処理できるよう実装


## 動作確認
```rb
rails c -s

# Railsコンソール起動後
user = User.first
movie, movie2 = Movie.limit(2)
WatchProgress.delete_all

user.watch_progresses.create!(movie_id: movie.id)
user.watch_progresses.create!(movie_id: movie2.id)

WatchProgress.count
#=> 2

movie.watch_progresses.create!(user_id: user.id)

WatchProgress.create!
```

- 動画教材一覧ページの視聴済み機能が動作していることを確認


## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

