### PR TITLE
テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: Text::RAILS_GENRE_LIST)
+    @texts = Text.genre_list(params[:genre])
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,12 @@ module ApplicationHelper
       "mw-xl"
     end
   end
+
+  def page_title
+    if params[:genre] == "php"
+      "PHP"
+    else
+      "Ruby/Rails"
+    end
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -17,6 +17,15 @@ class Text < ApplicationRecord
   }
 
   RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+  PHP_GENRE_LIST = %w[php].freeze
+
+  def self.genre_list(genre)
+    if genre == "php"
+      where(genre: Text::PHP_GENRE_LIST)
+    else
+      where(genre: Text::RAILS_GENRE_LIST)
+    end
+  end
 
   def read_by?(user)
     read_progresses.exists?(user_id: user.id)

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,5 +1,5 @@
 <h1 class="text-center mt-2 mb-4">
-  Ruby/Rails<br class="d-sm-none">
+  <%= page_title%><br class="d-sm-none">
   テキスト教材
 </h1>
 <div class="row">

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -3,5 +3,5 @@
   テキスト教材
 </h1>
 <div class="row">
-  <%= render @texts %>
+  <%= render  @texts %>
 </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -3,5 +3,5 @@
   テキスト教材
 </h1>
 <div class="row">
-  <%= render  @texts %>
+  <%= render @texts %>
 </div>


### PR DESCRIPTION

close #20

## 実装内容

 - PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正
   - `PHPテキスト教材`のリンクをクリックした際のクエリパラメータ`?genre=php`を利用
   - モデルにクラスメソッドを作成
 - 「Ruby/Railsテキスト教材ページ」のタイトルは「Ruby/Rails テキスト教材」，「PHPテキスト教材ページ」のタイトルは「PHP テキスト教材」とする
   - `app/helpers/application_helper.rb`にメソッドを作成して対応

## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
