### PR TITLE
リリース作業

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: bin/rails db:migrate

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,3 +48,7 @@ a:hover {
 .pagination {
   justify-content: center;
 }
+
+.navbar-brand img {
+  max-width: 240px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,6 +53,6 @@ a:hover {
   padding: 0;
   margin: 0;
   img {
-  max-width: 240px;
+    max-width: 240px;
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,6 +49,10 @@ a:hover {
   justify-content: center;
 }
 
-.navbar-brand img {
+.navbar-brand {
+  padding: 0;
+  margin: 0;
+  img {
   max-width: 240px;
+  }
 }

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,4 @@
 <h1><%= t('.sign_in') %></h1>
-<%= render 'layouts/flash' %>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-group">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-primary fixed-top">
   <%= link_to root_path, class: "navbar-brand" do %>
-    <%= image_tag("yanbaru_expert_logo.png")  %>
+    <%= image_tag("yanbaru_expert_logo.png") %>
   <% end %>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
  
close #24 

## 実装内容
  
- `Procfile`を作成して自動デプロイを設定
- Heroku へデプロイして初期データを投入
- ナビバーロゴのサイズ、 padding、margin を修正してフラッシュメッセージと重なっていたのを修正
- ログインページのフラッシュメッセージが重複して表示されていたのを修正

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## 備考
- ナビバーの修正、フラッシュメッセージの修正を追加実行
